### PR TITLE
Upgrade to Ember 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,18 @@ cache:
 env:
   matrix:
   - EMBER_TRY_SCENARIO=ember-1-12
+  - EMBER_TRY_SCENARIO=ember-1-13
+  - EMBER_TRY_SCENARIO=ember-2-0
+  - EMBER_TRY_SCENARIO=ember-2-1
+  - EMBER_TRY_SCENARIO=ember-2-2
+  - EMBER_TRY_SCENARIO=ember-2-3
+  - EMBER_TRY_SCENARIO=ember-2-4
+  - EMBER_TRY_SCENARIO=ember-2-5
+  - EMBER_TRY_SCENARIO=ember-2-6
+  - EMBER_TRY_SCENARIO=ember-2-7
+  - EMBER_TRY_SCENARIO=ember-2-8
+  - EMBER_TRY_SCENARIO=ember-2-9
+  - EMBER_TRY_SCENARIO=ember-2-10
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
@@ -28,6 +40,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+  - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
 before_install:
 - npm config set spin false

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-graphlib",
   "dependencies": {
-    "ember": "^2.10.2",
+    "ember": "^2.11.0",
     "ember-cli-shims": "0.1.1",
     "ember-mocha-adapter": "~0.3.1"
   }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -139,6 +139,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-2-10',
+      bower: {
+        dependencies: {
+          'ember': '~2.10.0'
+        },
+        resolutions: {
+          'ember': '~2.10.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
     "ciena-graphlib": "^1.0.1",
-    "ember-cli": "^2.10.1",
+    "ember-cli": "^2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "^0.3.2",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -38,7 +38,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.1.1",
     "ember-load-initializers": "^0.6.3",
-    "ember-lodash-shim": "^1.1.0",
+    "ember-lodash-shim": "^1.1.1",
     "ember-resolver": "^2.1.1",
     "eslint": "^3.14.0",
     "eslint-config-frost-standard": "^5.3.2",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** to test against Ember 2.11.
