### PR TITLE
Add shouldCompileJS workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,16 @@ const path = require('path')
 module.exports = {
   name: 'ciena-graphlib',
 
+  /**
+   * Workaround needed for 2.12+
+   * see: https://github.com/ember-redux/ember-redux/issues/105#issuecomment-288001558
+   * @returns {boolean} Set to true to force JS compile
+   * @private
+   */
+  _shouldCompileJS: function () {
+    return true
+  },
+
   treeForAddon (tree) {
     const graphlibPath = path.dirname(require.resolve('ciena-graphlib/src/index.js'))
 


### PR DESCRIPTION
Fixes import error with Ember 2.12

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Added `_shouldCompileJS()` to fix import error on Ember 2.12
