### PR TITLE
Change semver range of ember-export-application-global

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.1.1",
+    "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-lodash-shim": "^2.0.0",
     "ember-resolver": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ciena-graphlib": "^1.0.1",
     "ember-cli": "2.12.3",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Change semver range of `ember-export-application-global` to align with other repos